### PR TITLE
Remove newline from text

### DIFF
--- a/EmotionStimulusConverter.py
+++ b/EmotionStimulusConverter.py
@@ -23,6 +23,8 @@ def create_emo_stim_df(filename):
     labels = []
 
     def tag_remover_and_labeller(line):
+        line = line.replace("\n", "")
+        
         for emotion in emotions:
             emotion_tag = "<"+emotion+">"
             emotion_closing_tag = "<\\"+emotion+">"


### PR DESCRIPTION
Each headline is followed by a "\n" symbol in the dataset. This was causing every second row in the final .tsv file to be blank.
Removing the "\n" has seemed to fix this problem.